### PR TITLE
update thrift and scrooge version to make project compile again.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+client/.idea/*
+server/.idea/*

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -1,16 +1,14 @@
-name := "finagle-thrift-client-sample"
+// import com.twitter.scrooge.ScroogeSBT
+import sbt.Keys.libraryDependencies
 
-version := "1.0.0"
+name := "quickstart-client"
 
-scalaVersion  := "2.10.4"
+version := "1.0"
+scalaVersion := "2.11.6"
 
-resolvers ++= Seq(
-  "Twitter repository" at "http://maven.twttr.com"
-)
+lazy val app = project.in(file("."))
+  .settings(
+    libraryDependencies += "com.twitter" %% "finagle-http" % "19.11.0",
+    libraryDependencies += "com.twitter" %% "finagle-thrift" % "19.11.0"
+  )
 
-libraryDependencies ++= Seq(
-    "com.twitter" 			%% "scrooge-core"    % "3.17.0",
-    "com.twitter"       %% "finagle-thrift"  % "6.24.0"
-)
-
-com.twitter.scrooge.ScroogeSBT.newSettings

--- a/client/project/plugins.sbt
+++ b/client/project/plugins.sbt
@@ -1,3 +1,1 @@
-scalaVersion := "2.10.4"
-
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.16.3")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "19.11.0")

--- a/client/src/main/scala/FinagleThriftClientSampleApp.scala
+++ b/client/src/main/scala/FinagleThriftClientSampleApp.scala
@@ -1,6 +1,6 @@
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.twitter.conversions.time._
+import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.Thrift
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util.{Await, Duration, Future, Stopwatch}
@@ -14,7 +14,7 @@ object FinagleThriftClientSampleApp extends App {
   // Q: what may happened if the server is not started ? ... after using
   // and understanding better the code, try to add error handling for the
   // case that the server is not available
-  val client = Thrift.newIface[SampleService.FutureIface]("localhost:8080")
+  val client = Thrift.client.newIface[SampleService.FutureIface]("localhost:8080")
 
   // For having some fun, let's create a counter for tracing how many
   // requests we are performing. An atomic object is required to

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -1,16 +1,16 @@
-name := "finagle-thrift-server-sample"
+// import com.twitter.scrooge.ScroogeSBT
+import sbt.Keys.libraryDependencies
 
-version := "1.0.0"
+name := "quickstart-server"
 
-scalaVersion  := "2.10.4"
+version := "1.0"
+scalaVersion := "2.11.6"
 
-resolvers ++= Seq(
-  "Twitter repository" at "http://maven.twttr.com"
-)
+lazy val app = project.in(file("."))
+  .settings(
+    libraryDependencies += "com.twitter" %% "finagle-http" % "19.11.0",
+    libraryDependencies += "com.twitter" %% "finagle-thrift" % "19.11.0"
+  )
 
-libraryDependencies ++= Seq(
-    "com.twitter" 			%% "scrooge-core"    % "3.17.0",
-    "com.twitter"       %% "finagle-thrift"  % "6.24.0"
-)
 
-com.twitter.scrooge.ScroogeSBT.newSettings
+

--- a/server/project/plugins.sbt
+++ b/server/project/plugins.sbt
@@ -1,3 +1,1 @@
-scalaVersion := "2.10.4"
-
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.16.3")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "19.11.0")

--- a/server/src/main/scala/FinagleThriftServerSampleApp.scala
+++ b/server/src/main/scala/FinagleThriftServerSampleApp.scala
@@ -1,22 +1,21 @@
-import com.twitter.finagle.ListeningServer
+import com.sample.thrift.{SampleRequest, SampleResponse, SampleService}
 import com.twitter.finagle.Thrift
-import com.twitter.util.{Await, Future, Promise}
+import com.twitter.util.{Await, Future}
 
-import com.sample.thrift._
+
 
 object FinagleThriftServerSampleApp extends App {
 
   // The server part is easy in this sample, so let's just
   // create a simple implementation
-  val service = new SampleService[Future] {
+  val service: SampleService[Future] = new SampleService[Future] {
     def greet(request: SampleRequest): Future[SampleResponse] = {
       val response = SampleResponse(greeting = "Hello " + request.name)
       Future.value(response)
     }
   }
-
   // Run the service implemented on the port 8080
-  val server = Thrift.serveIface(":8080", service)
+  val server = Thrift.server.serveIface(":8080",service)
 
   // Keep waiting for the server and prevent the java process to exit
   // Q: What happens if we remove the await ?


### PR DESCRIPTION
I just made some minor changes in order to make the project compile again.

It seems like the versions of finagle were old and could not be retrieved from the twitter maven repository. One nice perk is that the project no longer depends on it, and everything is on maven central which should be more stable in the future.

Minor code changes were necessary to fix the breaking changes in the Thrift API.

